### PR TITLE
fix: allow local accounts without stored credentials

### DIFF
--- a/app/models/calendars/account.rb
+++ b/app/models/calendars/account.rb
@@ -15,6 +15,8 @@ module Calendars
     validates :username, presence: true, unless: :local?
     validates :encrypted_password, presence: true, unless: :local?
 
+    before_validation :normalize_local_credentials
+
     PROVIDERS = %w[fastmail icloud nextcloud google custom local].freeze
 
     def local?
@@ -22,6 +24,13 @@ module Calendars
     end
 
     private
+
+    def normalize_local_credentials
+      return unless local?
+
+      self.username = "" if username.blank?
+      self.encrypted_password = "" if encrypted_password.blank?
+    end
 
     def encryption_salt
       "calendar account password"

--- a/test/models/calendars/account_test.rb
+++ b/test/models/calendars/account_test.rb
@@ -40,6 +40,23 @@ module Calendars
       assert_includes account.errors[:encrypted_password], "can't be blank"
     end
 
+    test "local account saves without username or password" do
+      account = Calendars::Account.new(
+        tool: Tool.create!(
+          name: "Local-only calendar tool",
+          tool_type: tool_types(:calendar),
+          owner: users(:one)
+        ),
+        provider: "local",
+        sync_status: "pending"
+      )
+
+      assert account.save
+      assert_nil account.password
+      assert_equal "", account.username
+      assert_equal "", account.encrypted_password
+    end
+
     test "encrypts and decrypts password" do
       account = calendars_accounts(:icloud_account)
       account.password = "new-secret-password"


### PR DESCRIPTION
# Problem
When creating a local calendar account, a 500 error occurs.

Analyzing the container logs: 
`NOT NULL constraint failed: calendar_accounts.encrypted_password`

The issue is that local accounts are being saved without an encrypted_password, while the database schema enforces this column as NOT NULL.

Looking at the code, the password is only set if it’s present:

encrypted_password.rb
```ruby
def password=(new_password)
  return if new_password.blank?

  self.encrypted_password = encryptor.encrypt_and_sign(new_password)
end
```

For local accounts, password validation is skipped at the model level, but the database still requires a value:

```
validates :username, presence: true, unless: :local?
validates :encrypted_password, presence: true, unless: :local?

create_table "calendar_accounts", force: :cascade do |t|
  t.text "encrypted_password", null: false
  t.string "username", null: false
end
```
This incompatibility between the model validation and the database constraints is causing the error.

# Solution
Normalize values at the model level:

Add a before_validation callback
When the account is local, ensure both username and encrypted_password are set to empty strings ("") if they are blank.

This keeps the database constraints satisfied while preserving the intended behavior for local accounts.

## Test
Add a test to verify that a Calendars::Account with provider: local, and without username, password, or encrypted_password, is valid and can be saved successfully.