### PR TITLE
Allow null credentials on local calendar accounts

### DIFF
--- a/db/migrate/20260424053342_allow_null_credentials_for_local_calendar_accounts.rb
+++ b/db/migrate/20260424053342_allow_null_credentials_for_local_calendar_accounts.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AllowNullCredentialsForLocalCalendarAccounts < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :calendar_accounts, :username, true
+    change_column_null :calendar_accounts, :encrypted_password, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_07_072525) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_24_053342) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -61,7 +61,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_07_072525) do
     t.string "calendar_home_set_url"
     t.datetime "created_at", null: false
     t.string "display_name"
-    t.text "encrypted_password", null: false
+    t.text "encrypted_password"
     t.datetime "last_synced_at"
     t.string "principal_url"
     t.string "provider"
@@ -69,7 +69,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_07_072525) do
     t.string "sync_status", default: "pending"
     t.bigint "tool_id", null: false
     t.datetime "updated_at", null: false
-    t.string "username", null: false
+    t.string "username"
     t.index ["tool_id"], name: "index_calendar_accounts_on_tool_id", unique: true
   end
 

--- a/test/models/calendars/account_test.rb
+++ b/test/models/calendars/account_test.rb
@@ -40,6 +40,20 @@ module Calendars
       assert_includes account.errors[:encrypted_password], "can't be blank"
     end
 
+    test "local account saves without username or password" do
+      tool = Tool.create!(
+        name: "Local-only calendar",
+        tool_type: tool_types(:calendar),
+        owner: users(:one)
+      )
+      account = Calendars::Account.new(tool: tool, provider: "local", sync_status: "pending")
+
+      assert account.save, account.errors.full_messages.to_sentence
+      assert_nil account.password
+      assert_nil account.username
+      assert_nil account.encrypted_password
+    end
+
     test "encrypts and decrypts password" do
       account = calendars_accounts(:icloud_account)
       account.password = "new-secret-password"


### PR DESCRIPTION
## Summary

Fixes the 500 error surfaced in #42: creating a local calendar account crashes on the NOT NULL constraints for \`username\` and \`encrypted_password\`.

The \`Calendars::Account\` model already skips those validations for local accounts (\`unless: :local?\`) — the DB schema just didn't agree. This PR loosens the schema to match the model's intent.

Smaller alternative to #42, which patched the symptom by writing empty strings. Empty-string sentinels for "no credentials" are hard to grep for and confuse anyone reading the schema.

## Test plan

- [x] New test: \`local account saves without username or password\` — confirms a \`provider: "local"\` account persists with genuinely-nil credentials (not empty strings).
- [x] Existing validation tests for non-local accounts still pass (the model's \`unless: :local?\` continues to enforce credentials for CalDAV providers).
- [x] Full test suite: 295 runs, 801 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)