### PR TITLE
Fix stored DOM-XSS in public shared-folder gallery (GHSA-m95v-4xq6-grhg)

### DIFF
--- a/app/javascript/controllers/mail_bulk_controller.js
+++ b/app/javascript/controllers/mail_bulk_controller.js
@@ -1,0 +1,41 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Manages bulk selection in the mail list: select-all, per-row checkboxes,
+// showing/hiding the bulk-action toolbar, and submitting move-to-folder.
+export default class extends Controller {
+  static targets = ["checkbox", "selectAll", "actions"]
+
+  toggleAll() {
+    const checked = this.selectAllTarget.checked
+    this.checkboxTargets.forEach(cb => cb.checked = checked)
+    this.updateActions()
+  }
+
+  toggle(event) {
+    // Keep ticking the box from triggering the row's navigation.
+    event.stopPropagation()
+    this.updateActions()
+  }
+
+  updateActions() {
+    const anyChecked = this.checkboxTargets.some(cb => cb.checked)
+    this.actionsTarget.classList.toggle("hidden", !anyChecked)
+  }
+
+  moveToFolder(event) {
+    this.setHidden("action_type", "move_to_folder")
+    this.setHidden("target_folder", event.currentTarget.dataset.folder)
+    this.element.requestSubmit()
+  }
+
+  setHidden(name, value) {
+    let input = this.element.querySelector(`input[type="hidden"][name="${name}"]`)
+    if (!input) {
+      input = document.createElement("input")
+      input.type = "hidden"
+      input.name = name
+      this.element.appendChild(input)
+    }
+    input.value = value
+  }
+}

--- a/app/javascript/controllers/public_gallery_controller.js
+++ b/app/javascript/controllers/public_gallery_controller.js
@@ -46,11 +46,21 @@ export default class extends Controller {
 
   showImage() {
     const img = this.images[this.currentIndex]
-    this.lightboxContentTarget.innerHTML = `<img src="${img.url}" alt="${img.name}">`
-    this.lightboxInfoTarget.innerHTML = `
-      <span class="font-medium">${img.name}</span>
-      <span class="opacity-70 text-sm">${this.currentIndex + 1} / ${this.images.length}</span>
-    `
+
+    this.lightboxContentTarget.replaceChildren()
+    const imgEl = document.createElement("img")
+    imgEl.src = img.url
+    imgEl.alt = img.name
+    this.lightboxContentTarget.appendChild(imgEl)
+
+    this.lightboxInfoTarget.replaceChildren()
+    const nameSpan = document.createElement("span")
+    nameSpan.className = "font-medium"
+    nameSpan.textContent = img.name
+    const countSpan = document.createElement("span")
+    countSpan.className = "opacity-70 text-sm"
+    countSpan.textContent = `${this.currentIndex + 1} / ${this.images.length}`
+    this.lightboxInfoTarget.append(nameSpan, countSpan)
   }
 
   handleKeydown(event) {

--- a/app/javascript/controllers/recovery_code_controller.js
+++ b/app/javascript/controllers/recovery_code_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Switches the 2FA verification field from a 6-digit OTP to accept a longer
+// recovery code, and hides the "use a recovery code" prompt.
+export default class extends Controller {
+  static targets = ["field", "prompt"]
+
+  reveal() {
+    this.fieldTarget.removeAttribute("inputmode")
+    this.fieldTarget.setAttribute("maxlength", "20")
+    this.fieldTarget.focus()
+    this.promptTarget.classList.add("hidden")
+  }
+}

--- a/app/views/tools/mails/_conversation_item.html.erb
+++ b/app/views/tools/mails/_conversation_item.html.erb
@@ -1,7 +1,7 @@
 <%# Locals: conversation, tool, current_folder, selected_message %>
 <% is_selected = selected_message&.thread_id == conversation[:thread_id] %>
 <div id="conversation-<%= conversation[:id] %>" class="mail-list-item flex items-start gap-3 px-3 py-2.5 border-b border-border-light border-l-2 border-l-transparent transition-all cursor-pointer hover:bg-background-tertiary <%= 'selected' if is_selected %>" data-mail-keyboard-target="item">
-  <input type="checkbox" name="message_ids[]" value="<%= conversation[:id] %>" class="mail-list-checkbox w-4 h-4 rounded accent-accent flex-shrink-0 mt-0.5" onclick="event.stopPropagation()" onchange="document.getElementById('bulk-actions').classList.toggle('hidden', !document.querySelector('.mail-list-checkbox:checked'))">
+  <input type="checkbox" name="message_ids[]" value="<%= conversation[:id] %>" class="mail-list-checkbox w-4 h-4 rounded accent-accent flex-shrink-0 mt-0.5" data-mail-bulk-target="checkbox" data-action="click->mail-bulk#toggle">
   <% conversation_href = conversation[:draft] ? new_tool_mail_path(tool, draft_id: conversation[:id]) : tool_mail_path(tool, conversation[:id], folder: current_folder) %>
   <% conversation_data = conversation[:draft] ? { turbo_frame: "_top" } : { turbo_frame: "mail-content", turbo: "true", action: "click->mail-keyboard#selectItem" } %>
   <%= link_to conversation_href, class: "flex-1 min-w-0 no-underline", data: conversation_data do %>

--- a/app/views/tools/mails/index.html.erb
+++ b/app/views/tools/mails/index.html.erb
@@ -186,13 +186,13 @@
       </div>
     <% end %>
 
-    <%= form_with url: tool_bulk_path(@tool), method: :post, id: "bulk-form" do %>
+    <%= form_with url: tool_bulk_path(@tool), method: :post, id: "bulk-form", data: { controller: "mail-bulk" } do %>
       <input type="hidden" name="folder" value="<%= @current_folder %>">
 
       <% if @conversations.any? %>
         <div class="flex items-center px-3 py-0.5 min-h-9 border-b border-border-light bg-background-secondary gap-3">
-          <input type="checkbox" class="w-4 h-4 rounded accent-accent ml-[2px]" id="select-all" onchange="document.querySelectorAll('.mail-list-checkbox').forEach(cb => cb.checked = this.checked); document.getElementById('bulk-actions').classList.toggle('hidden', !this.checked)">
-          <div id="bulk-actions" class="flex items-center gap-1 hidden">
+          <input type="checkbox" class="w-4 h-4 rounded accent-accent ml-[2px]" data-mail-bulk-target="selectAll" data-action="change->mail-bulk#toggleAll">
+          <div class="flex items-center gap-1 hidden" data-mail-bulk-target="actions">
             <% if @current_folder == "trash" %>
               <%= render "components/icon_button", icon: "trash-2", title: "Delete forever", type: :submit, name: "action_type", value: "delete", size: :sm %>
               <%= render "components/icon_button", icon: "rotate-ccw", title: "Restore", type: :submit, name: "action_type", value: "restore", size: :sm %>
@@ -215,7 +215,7 @@
                   %>
                   <% bulk_move_folders.each do |folder_name, icon, label| %>
                     <button type="button" class="dropdown-item flex items-center gap-2"
-                            onclick="const f=this.closest('form');f.querySelector('[name=action_type]')?.remove();const at=document.createElement('input');at.type='hidden';at.name='action_type';at.value='move_to_folder';f.appendChild(at);const tf=document.createElement('input');tf.type='hidden';tf.name='target_folder';tf.value='<%= j folder_name %>';f.appendChild(tf);f.requestSubmit();">
+                            data-action="mail-bulk#moveToFolder" data-folder="<%= folder_name %>">
                       <%= render "shared/icon", name: icon, size: 16 %>
                       <span><%= label %></span>
                     </button>

--- a/app/views/two_factor_challenges/new.html.erb
+++ b/app/views/two_factor_challenges/new.html.erb
@@ -8,7 +8,7 @@
   </div>
 
   <div class="card">
-    <div class="card-body">
+    <div class="card-body" data-controller="recovery-code">
       <%= form_with url: two_factor_challenge_path, method: :post, class: "space-y-4" do |f| %>
         <div>
           <label for="code" class="label">Verification code</label>
@@ -19,16 +19,17 @@
             autofocus: true,
             autocomplete: "one-time-code",
             inputmode: "numeric",
-            maxlength: 8
+            maxlength: 8,
+            data: { recovery_code_target: "field" }
           %>
         </div>
 
         <%= render "components/button", text: "Verify", full_width: true %>
       <% end %>
 
-      <p class="text-center text-sm text-text-tertiary mt-3">
+      <p class="text-center text-sm text-text-tertiary mt-3" data-recovery-code-target="prompt">
         Lost your device?
-        <button type="button" class="text-accent hover:underline" onclick="this.closest('.card-body').querySelector('[inputmode]').removeAttribute('inputmode'); this.closest('.card-body').querySelector('[maxlength]').setAttribute('maxlength', '20'); this.closest('p').classList.add('hidden')">
+        <button type="button" class="text-accent hover:underline" data-action="recovery-code#reveal">
           Use a recovery code
         </button>
       </p>

--- a/app/views/two_factor_setups/create.html.erb
+++ b/app/views/two_factor_setups/create.html.erb
@@ -8,7 +8,7 @@
       <p class="text-sm text-text-secondary mt-1">Save these recovery codes in a safe place</p>
     </div>
 
-    <div class="bg-background-secondary rounded-lg p-4">
+    <div class="bg-background-secondary rounded-lg p-4" data-controller="clipboard">
       <p class="text-sm text-text-secondary mb-3">
         Use these codes to sign in if you lose access to your authenticator app. Each code can only be used once.
       </p>
@@ -17,9 +17,11 @@
           <code class="px-3 py-2 bg-surface rounded text-sm font-mono text-text-primary text-center select-all"><%= code %></code>
         <% end %>
       </div>
+      <textarea class="hidden" data-clipboard-target="source"><%= @recovery_codes.join("\n") %></textarea>
       <button type="button"
               class="btn btn-primary btn-sm w-full mt-3"
-              onclick="navigator.clipboard.writeText('<%= @recovery_codes.join('\n') %>'); this.textContent = 'Copied!'; setTimeout(() => this.textContent = 'Copy all codes', 2000)">
+              data-clipboard-target="button"
+              data-action="clipboard#copy">
         Copy all codes
       </button>
     </div>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -21,6 +21,7 @@ Rails.application.configure do
   config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
   config.content_security_policy_nonce_directives = %w[script-src]
 
-  # Report violations without enforcing the policy.
-  config.content_security_policy_report_only = true
+  # Enforce the policy: inline event handlers and non-nonced inline scripts are
+  # blocked, so a DOM-XSS sink can't execute injected JavaScript.
+  config.content_security_policy_report_only = false
 end


### PR DESCRIPTION
## Summary

Fixes the stored DOM-XSS reported in **GHSA-m95v-4xq6-grhg** (CWE-79).

The public, unauthenticated shared-folder image gallery interpolated an
attacker-controlled file `name` into `innerHTML` in `public_gallery_controller.js#showImage`.
ERB escapes the `data-name` attribute, but the browser decodes it back on
`el.dataset.name`, so re-parsing via `innerHTML` undid the escape. A filename like
`"><img src=x onerror=...>` executed for any visitor to `/s/<token>` who clicked a thumbnail.

## Fix

- **Sink:** build the lightbox via DOM APIs (`createElement`, `.src`/`.alt` setters,
  `textContent`) which never parse HTML — the stored payload renders inert.
- **Defense-in-depth:** flip the CSP from report-only to **enforcing**, so a future
  inline-handler sink can't execute. Required removing all 5 pre-existing inline `on*=`
  handlers, converted to Stimulus:
  - `mail_bulk_controller` — mail bulk select-all / per-row checkbox / move-to-folder
  - `recovery_code_controller` — 2FA challenge "use a recovery code"
  - existing `clipboard_controller` — 2FA recovery-codes copy

## Verification

- Reproduced the exploit against the fix: payload no longer executes, only the real
  `<img>` is rendered, name shows as literal text. CSP header confirmed enforcing.
- No console/CSP violations on the public page (Stimulus runs fine under enforcing CSP).
- `bin/brakeman` 0 warnings, `bin/rubocop` clean, 38 mail/2FA/files controller tests pass.

Reported by **tonghuaroot (童话)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)